### PR TITLE
Added support for custom post types using the PMPro CPT plugin

### DIFF
--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -99,8 +99,17 @@ function pmproap_post_save($post_id)
 
 function pmproap_post_meta_wrapper()
 {
-	add_meta_box('pmproap_post_meta', 'PMPro Addon Package Settings', 'pmproap_post_meta', 'page', 'normal');
-	add_meta_box('pmproap_post_meta', 'PMPro Addon Package Settings', 'pmproap_post_meta', 'post', 'normal');
+	// default post types to display
+	$display_post_types = array ('page', 'post');
+
+	// get extra post types from PMPro CPT, if available
+	if(function_exists('pmprocpt_getCPTs')) {
+		$display_post_types = array_merge($display_post_types, pmprocpt_getCPTs());
+	}
+
+	foreach($display_post_types as $display_post_type) {
+		add_meta_box('pmproap_post_meta', 'PMPro Addon Package Settings', 'pmproap_post_meta', $display_post_type, 'normal');
+	}
 }
 if (is_admin())
 {


### PR DESCRIPTION
Instead of only adding the metabox to posts and pages, it is now added to the admin page of all CPTs you select in the PMPro CPT plugin.

This fixes issue #12 

(Sorry if this is overly bureaucratic, I wanted to be thorough and did not imagine it to be this easy).