### PR TITLE
No longer pulling level from $_REQUEST

### DIFF
--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -577,10 +577,13 @@ function pmproap_gettext_you_have_selected( $translated_text, $text, $domain ) {
 	if ( ! empty( $pmpro_pages ) && is_page( $pmpro_pages['checkout'] ) &&
 		! empty( $_REQUEST['ap'] ) &&
 		$domain == 'paid-memberships-pro' &&
-		strpos( $text, 'have selected' ) !== false &&
-		pmpro_hasMembershipLevel( intval( $_REQUEST['level'] ) ) ) {
-		$translated_text = str_replace( __( ' membership level', 'pmpro-addon-packages' ), '', $translated_text );
-		$translated_text = str_replace( __( 'You have selected the', 'pmpro-addon-packages' ), __( 'You are purchasing additional access to:', 'pmpro-addon-packages' ), $translated_text );
+		strpos( $text, 'have selected' ) !== false ) {
+		// Get the level being purchased.
+		$checkout_level = pmpro_getLevelAtCheckout();
+		if ( ! empty( $checkout_level ) && pmpro_hasMembershipLevel( $checkout_level->id ) ) {
+			$translated_text = str_replace( __( ' membership level', 'pmpro-addon-packages' ), '', $translated_text );
+			$translated_text = str_replace( __( 'You have selected the', 'pmpro-addon-packages' ), __( 'You are purchasing additional access to:', 'pmpro-addon-packages' ), $translated_text );
+		}
 	}
 	return $translated_text;
 }


### PR DESCRIPTION
Should only be merged once this PR is confirmed to be merged into the PMPro v3.0 branch: https://github.com/strangerstudios/paid-memberships-pro/pull/2506

This PR specifically stops pulling the checkout level from the `$_REQUEST` variable (since we are prefixing the `level` parameter in 3.0) and instead uses the `pmpro_getLevelAtCheckout()` function.