### PR TITLE
No access message for PMPro v3.1

### DIFF
--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -767,15 +767,9 @@ add_filter( 'pmpro_confirmation_message', 'pmproap_pmpro_confirmation_message' )
 /**
  * Show purchased posts on the account page
  */
-function pmproap_pmpro_member_links_top( $invoice = NULL) {
-	if( !empty( $invoice ) ) {
-		$user_id = $invoice->user_id;
-	}
-
-	if( empty($user_id ) ) {
-		global $current_user;
-		$user_id = $current_user->ID;
-	}
+function pmproap_pmpro_member_links_top() {
+	global $current_user;
+	$user_id = $current_user->ID;
 
 	$post_ids = get_user_meta( $user_id, '_pmproap_posts', true );
 	if ( is_array( $post_ids ) ) {
@@ -787,14 +781,77 @@ function pmproap_pmpro_member_links_top( $invoice = NULL) {
 				continue;
 			}
 			?>
-			<li><a href="<?php echo get_permalink( $post_id ); ?>"><?php echo $apost->post_title; ?></a></li>
+			<li class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_list_item' ) ); ?>">
+				<a href="<?php echo get_permalink( $post_id ); ?>"><?php echo $apost->post_title; ?></a>
+				<?php
+					// Get the expiration date for the Addon Package.
+					$pmproap_ap_exp_date = get_user_meta( $user_id, 'pmproap_post_id_' . $post_id . '_exp_date', true );
+
+					if ( ! empty( $pmproap_ap_exp_date ) ) {
+						printf( __( '(Access expires on %s)', 'pmpro-addon-packages' ), esc_html( date_i18n( get_option( 'date_format' ), $pmproap_ap_exp_date ) ) );
+					}
+				?>
+			</li>
 			<?php
 		}
 	}
 }
-
 add_action( 'pmpro_member_links_top', 'pmproap_pmpro_member_links_top' );
-add_action( 'pmpro_invoice_bullets_top', 'pmproap_pmpro_member_links_top' );
+
+/**
+ * Show purchased post on the order.
+ *
+ * @since TBD
+ *
+ * @param  string $pmpro_order_single_meta The order meta.
+ * @param  object $pmpro_order             The order object.
+ * @return string                          The filtered order meta.
+ */
+function pmproap_pmpro_order_single_meta( $pmpro_order_single_meta, $pmpro_order ) {
+	// If the invoice is empty, return the order meta.
+	if ( empty( $pmpro_order ) ) {
+		return $pmpro_order_single_meta;
+	}
+
+	// Get the Addon Package post ID from the order notes.
+	$pmpro_order_notes = $pmpro_order->notes;
+
+	// If the notes are empty, return the order meta.
+	if ( empty( $pmpro_order_notes ) ) {
+		return $pmpro_order_single_meta;
+	}
+
+	// Get the Addon Package post ID from the order notes.
+	preg_match( '/Addon Package:(.*)\(#(\d+)\)/', $pmpro_order_notes, $matches );
+	$pmproap_ap_id = $matches[2];
+	if ( empty( $pmproap_ap_id ) ) {
+		return $pmpro_order_single_meta;
+	}
+
+	// Show the Addon Package on the order if it is published.
+	$apost = get_post( $pmproap_ap_id );
+	if ( empty( $apost ) || $apost->post_status != 'publish' ) {
+		return $pmpro_order_single_meta;
+	}
+
+	// Return if this user no longer has access to the Addon Package.
+	if ( ! pmproap_hasAccess( $pmpro_order->user_id, $pmproap_ap_id ) ) {
+		return $pmpro_order_single_meta;
+	}
+
+	$pmpro_order_single_meta['addon_package']['label'] = esc_html__( 'Additional Access', 'pmpro-addon-packages' );
+	$pmpro_order_single_meta['addon_package']['value'] = '<a href="' . get_permalink( $pmproap_ap_id ) . '">' . $apost->post_title . '</a>';
+
+	// Get the expiration date for the Addon Package.
+	$pmproap_ap_exp_date = get_user_meta( $pmpro_order->user_id, 'pmproap_post_id_' . $pmproap_ap_id . '_exp_date', true );
+
+	if ( ! empty( $pmproap_ap_exp_date ) ) {
+		$pmpro_order_single_meta['addon_package']['value'] .= '<br />' . sprintf( __( 'Expires on %s', 'pmpro-addon-packages' ), esc_html( date_i18n( get_option( 'date_format' ), $pmproap_ap_exp_date ) ) );
+	}
+
+	return $pmpro_order_single_meta;
+}
+add_action( 'pmpro_order_single_meta', 'pmproap_pmpro_order_single_meta', 10, 2 );
 
 /**
  * Show the purchased pages for each user on the edit user/profile  page of the admin

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -300,7 +300,7 @@ function pmproap_pmpro_text_filter( $text ) {
 
 			if ( empty( $text_level_id ) ) {
 				$text = '<p>' . __( 'You must first purchase a membership level before purchasing this content. ', 'pmpro-addon-packages' ) . '</p>';
-				$text .= '<p><a href="' . pmpro_url( 'levels' ) . '">' . __( 'Click here to choose a membership level.', 'pmpro-addon-packages' ) . '</a></p>';
+				$text .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . pmpro_url( 'levels' ) . '">' . __( 'Choose a Membership Level', 'pmpro-addon-packages' ) . '</a></p>';
 			} else {
 				// what's the price
 				$pmproap_price = get_post_meta( $post->ID, '_pmproap_price', true );
@@ -317,10 +317,10 @@ function pmproap_pmpro_text_filter( $text ) {
 					}
 
 					$text = '<p>' . sprintf( __( 'This content requires that you purchase additional access. The price is %1$s or free for our %2$s members.', 'pmpro-addon-packages' ), pmpro_formatPrice( $pmproap_price ), pmpro_implodeToEnglish( $level_names ) ) . '</p>';
-					$text .= '<p><a href="' . pmpro_url( 'checkout', '?level=' . $text_level_id . '&ap=' . $post->ID ) . '">' . sprintf( __( 'Purchase this Content (%s)', 'pmpro-addon-packages' ), pmpro_formatPrice( $pmproap_price ) ) . '</a> <a href="' . pmpro_url( 'levels' ) . '">' . __( 'Choose a Membership Level', 'pmpro-addon-packages' ) . '</a></p>';
+					$text .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . pmpro_url( 'checkout', '?level=' . $text_level_id . '&ap=' . $post->ID ) . '">' . sprintf( __( 'Purchase this Content (%s)', 'pmpro-addon-packages' ), pmpro_formatPrice( $pmproap_price ) ) . '</a> <a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . pmpro_url( 'levels' ) . '">' . __( 'Choose a Membership Level', 'pmpro-addon-packages' ) . '</a></p>';
 				} else {
 					$text = '<p>' . sprintf( __( 'This content requires that you purchase additional access. The price is %s.', 'pmpro-addon-packages' ), pmpro_formatPrice( $pmproap_price ) ) . '</p>';
-					$text .= '<p><a href="' . pmpro_url( 'checkout', '?level=' . $text_level_id . '&ap=' . $post->ID ) . '">' . __( 'Click here to checkout', 'pmpro-addon-packages' ) . '</a></p>';
+					$text .= '<p><a class="' . pmpro_get_element_class( 'pmpro_btn' ) . '" href="' . pmpro_url( 'checkout', '?level=' . $text_level_id . '&ap=' . $post->ID ) . '">' . __( 'Click Here to Check Out', 'pmpro-addon-packages' ) . '</a></p>';
 				}
 			}
 		}

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -261,10 +261,37 @@ function pmproap_pmpro_has_membership_access_filter( $hasaccess, $mypost, $myuse
 add_filter( 'pmpro_has_membership_access_filter', 'pmproap_pmpro_has_membership_access_filter', 10, 4 );
 
 /**
+ * Filter the header message for the no access message.
+ *
+ * @since TBD
+ *
+ * @param string $header The header message for the no access message.
+ * @return string The filtered header message for the no access message.
+ */
+function pmproap_no_access_message_header( $header ) {
+	global $current_user, $post;
+
+	// We are running PMPro v3.1+, so make sure that deprecated filters don't run later.
+	remove_filter( 'pmpro_non_member_text_filter', 'pmproap_pmpro_text_filter' );
+	remove_filter( 'pmpro_not_logged_in_text_filter', 'pmproap_pmpro_text_filter' );
+
+	// Check if the post is locked and the user doesn't have access.
+	if ( ! empty( $post ) && pmproap_isPostLocked( $post->ID ) && ! pmproap_hasAccess( $current_user->ID, $post->ID ) ) {
+		$header = __( 'Purchase Required', 'pmpro-addon-packages' );
+	}
+
+	return $header;
+}
+add_filter( 'pmpro_no_access_message_header', 'pmproap_no_access_message_header' ); // PMPro v3.1+.
+
+/**
  * Filter the message for users without access.
+ *
+ * @param string $text The message for users without access.
+ * @return string The filtered message for users without access.
  */
 function pmproap_pmpro_text_filter( $text ) {
-	global $wpdb, $current_user, $post, $pmpro_currency_symbol;
+	global $current_user, $post;
 
 	if ( ! empty( $post ) ) {
 		if ( pmproap_isPostLocked( $post->ID ) && ! pmproap_hasAccess( $current_user->ID, $post->ID ) ) {
@@ -301,9 +328,9 @@ function pmproap_pmpro_text_filter( $text ) {
 
 	return $text;
 }
-
-add_filter( 'pmpro_non_member_text_filter', 'pmproap_pmpro_text_filter' );
-add_filter( 'pmpro_not_logged_in_text_filter', 'pmproap_pmpro_text_filter' );
+add_filter( 'pmpro_no_access_message_body', 'pmproap_pmpro_text_filter' ); // PMPro v3.1+.
+add_filter( 'pmpro_non_member_text_filter', 'pmproap_pmpro_text_filter' ); // Pre-PMPro v3.1.
+add_filter( 'pmpro_not_logged_in_text_filter', 'pmproap_pmpro_text_filter' ); // Pre-PMPro v3.1.
 
 /**
  * Figure out which PMPro level ID to use for the checkout link for an addon page.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-addon-packages/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-addon-packages/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
No longer using deprecated filters.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
