### PR TITLE
Use posts defined in `pmproap_supported_post_types`

### DIFF
--- a/shortcodes/pmpro-addon-packages-shortcode.php
+++ b/shortcodes/pmpro-addon-packages-shortcode.php
@@ -37,7 +37,8 @@
 		}
 		else
 		{
-			$post_type = array('post', 'page');
+			//Apply filter
+			$post_type = apply_filters( 'pmproap_supported_post_types', array( 'page', 'post' ) );
 			$post_parent = NULL;
 
 			//including post IDs


### PR DESCRIPTION
https://github.com/strangerstudios/pmpro-addon-packages/issues/45

### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-addon-packages/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-addon-packages/pulls/) for the same update/change?


### Changes proposed in this Pull Request:

Resolves #45 

### How to test the changes in this Pull Request:

1. Add post types defined in 'pmproap_supported_post_types' in shortcode query.


### Changelog entry

Changes $post_type variable to use posts defined in 'pmproap_supported_post_types'.
