### PR TITLE
Fix checkout page warnings and errors

### DIFF
--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -370,7 +370,7 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 
 	$text_level_id = null;
 	if ( ! empty( $current_user->membership_levels ) ) {
-		// Find the first member's level that allows addon purchase.
+		// Find the first of the user's levels that is required for this post and still allows signups.
 		foreach ( $current_user->membership_levels as $level ) {
 			if ( empty( $level->allow_signups ) || ! in_array( $level->id, $post_levels ) ) {
 				continue;
@@ -381,21 +381,10 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 	}
 
 	// Didn't find a level id to use yet? Find a free level to checkout with.
-	if ( empty( $text_level_id ) ) {
+	if ( empty( $text_level_id ) && ! empty( $post_levels ) ) {
 		foreach ( $post_levels as $post_level_id ) {
 			$post_level = pmpro_getLevel( $post_level_id );
 			if ( ! empty( $post_level->allow_signups ) && pmpro_isLevelFree( $post_level ) ) {
-				$text_level_id = $post_level->id;
-				break;
-			}
-		}
-	}
-
-	// Didn't find a level id to use yet? Find a paid level to checkout with.
-	if ( empty( $text_level_id ) ) {
-		foreach ( $post_levels as $post_level_id ) {
-			$post_level = pmpro_getLevel( $post_level_id );
-			if ( ! pmpro_isLevelFree( $post_level ) && ! empty( $post_level->allow_signups ) ) {
 				$text_level_id = $post_level->id;
 				break;
 			}

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -378,8 +378,10 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 			$text_level_id = $level->id;
 			break;
 		}
-	} else {
-		// Find the first free post level that allows addon purchase.
+	}
+
+	// Didn't find a level id to use yet? Find a free level to checkout with.
+	if ( empty( $text_level_id ) ) {
 		foreach ( $post_levels as $post_level_id ) {
 			$post_level = pmpro_getLevel( $post_level_id );
 			if ( ! empty( $post_level->allow_signups ) && pmpro_isLevelFree( $post_level ) ) {

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -658,6 +658,11 @@ add_filter( 'pmpro_confirmation_url', 'pmproap_pmpro_confirmation_url', 10, 3 );
  */
 function pmproap_pmpro_checkout_level_have_it( $level ) {
 	global $pmpro_pages;
+	// Bail if level object or level description is empty.
+	if ( empty( $level ) || empty( $level->description ) ) {
+		return $level;
+	}
+
 	// only checkout page, with ap passed in, and have the level checking out for
 	if ( is_page( $pmpro_pages['checkout'] ) &&
 		! empty( $_REQUEST['ap'] ) &&

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -370,19 +370,30 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 
 	$text_level_id = null;
 	if ( ! empty( $current_user->membership_levels ) ) {
-		foreach ( $current_user->membership_levels as $key => $level ) {
-			// Skip levels that do not allow signups.
-			if ( empty( $level->allow_signups ) ) {
+		// Find the first member's level that allows addon purchase.
+		foreach ( $current_user->membership_levels as $level ) {
+			if ( empty( $level->allow_signups ) || ! in_array( $level->id, $post_levels ) ) {
 				continue;
 			}
 			$text_level_id = $level->id;
 			break;
 		}
-	} elseif ( ! empty( $post_levels ) ) {
-		// find a free level to checkout with
+	} else {
+		// Find the first free post level that allows addon purchase.
 		foreach ( $post_levels as $post_level_id ) {
 			$post_level = pmpro_getLevel( $post_level_id );
-			if ( pmpro_isLevelFree( $post_level ) ) {
+			if ( ! empty( $post_level->allow_signups ) && pmpro_isLevelFree( $post_level ) ) {
+				$text_level_id = $post_level->id;
+				break;
+			}
+		}
+	}
+
+	// Didn't find a level id to use yet? Find a paid level to checkout with.
+	if ( empty( $text_level_id ) ) {
+		foreach ( $post_levels as $post_level_id ) {
+			$post_level = pmpro_getLevel( $post_level_id );
+			if ( ! pmpro_isLevelFree( $post_level ) && ! empty( $post_level->allow_signups ) ) {
 				$text_level_id = $post_level->id;
 				break;
 			}

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -369,8 +369,16 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 	}
 
 	$text_level_id = null;
-	if ( ! empty( $current_user->membership_levels ) && ! empty( array_intersect( wp_list_pluck( $current_user->membership_levels, 'id' ), $post_levels ) ) ) {
-		$text_level_id = current( array_intersect( wp_list_pluck( $current_user->membership_levels, 'id' ), $post_levels ) );
+	if ( ! empty( $current_user->membership_levels ) ) {
+		foreach ( $current_user->membership_levels as $key => $level ) {
+			// Skip levels that do not allow signups.
+			$level_obj = pmpro_getLevel( $level->id );
+			if ( empty( $level_obj ) || empty( $level_obj->allow_signups ) ) {
+				continue;
+			}
+			$text_level_id = $level->id;
+			break;
+		}
 	} elseif ( ! empty( $post_levels ) ) {
 		// find a free level to checkout with
 		foreach ( $post_levels as $post_level_id ) {

--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -372,8 +372,7 @@ function pmproap_getLevelIDForCheckoutLink( $post_id = null, $user_id = null ) {
 	if ( ! empty( $current_user->membership_levels ) ) {
 		foreach ( $current_user->membership_levels as $key => $level ) {
 			// Skip levels that do not allow signups.
-			$level_obj = pmpro_getLevel( $level->id );
-			if ( empty( $level_obj ) || empty( $level_obj->allow_signups ) ) {
+			if ( empty( $level->allow_signups ) ) {
 				continue;
 			}
 			$text_level_id = $level->id;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-addon-packages/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-addon-packages/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Checking whether description property exists on the level object before attempting to set values to avoid errors/warnings.

Sending active members of signup disabled levels to checkout page for the first free level or first paid level that allows addon package purchase.

A customer reported an issue where a fatal error was being triggered at addon package checkout for members of levels for which signup is disabled, if the member's current level was one of the levels required for the addon package purchase. Replicated. Recommended Level Groups as an alternative.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Resolves errors that could be triggered on the checkout page for existing members if signups were disabled for their level.
