### PR TITLE
Prevent undefined array key warning on orders admin page

### DIFF
--- a/pmpro-addon-packages.php
+++ b/pmpro-addon-packages.php
@@ -828,10 +828,10 @@ function pmproap_pmpro_order_single_meta( $pmpro_order_single_meta, $pmpro_order
 
 	// Get the Addon Package post ID from the order notes.
 	preg_match( '/Addon Package:(.*)\(#(\d+)\)/', $pmpro_order_notes, $matches );
-	$pmproap_ap_id = $matches[2];
-	if ( empty( $pmproap_ap_id ) ) {
+	if ( empty( $matches[2] ) ) {
 		return $pmpro_order_single_meta;
 	}
+	$pmproap_ap_id = $matches[2];
 
 	// Show the Addon Package on the order if it is published.
 	$apost = get_post( $pmproap_ap_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-addon-packages/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-addon-packages/pulls/) for the same update/change?

 ### Changes proposed in this Pull Request:

Guards against a PHP "Undefined array key 2" warning on line 831 of `pmpro-addon-packages.php`. 
  
When `preg_match()` runs against order notes that don't match the `Addon Package:(.*)\(#(\d+)\)` pattern, `$matches[2]` is not set. 

The fix checks `empty( $matches[2] )` before assigning it to `$pmproap_ap_id`, returning early if the pattern wasn't found.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
> Fixed a PHP "Undefined array key" warning that occurred when order notes did not match the expected Addon Package pattern.